### PR TITLE
test_runner: persist randomization seed in rerun-failures state file

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2928,7 +2928,12 @@ enables randomization implicitly, even without `--test-randomize`.
 
 The value must be an integer between `0` and `4294967295`.
 
-This flag cannot be used with `--watch` or `--test-rerun-failures`.
+This flag cannot be used with `--watch`.
+
+When combined with `--test-rerun-failures`, the seed is persisted in the
+rerun state file so that a subsequent rerun reproduces the same execution order.
+An explicitly provided `--test-random-seed` takes precedence over the persisted
+seed.
 
 ### `--test-randomize`
 
@@ -2948,7 +2953,11 @@ reused with `--test-random-seed`.
 For detailed behavior and examples, see
 [randomizing tests execution order][].
 
-This flag cannot be used with `--watch` or `--test-rerun-failures`.
+This flag cannot be used with `--watch`.
+
+When combined with `--test-rerun-failures`, the randomization seed is
+persisted in the rerun state file so that a subsequent rerun reproduces the same
+execution order.
 
 ### `--test-reporter`
 

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -793,6 +793,12 @@ describe('math', () => {
 
 `--test-randomize` and `--test-random-seed` are not supported with `--watch` mode.
 
+When `--test-randomize` or `--test-random-seed` is combined with
+`--test-rerun-failures`, the randomization seed is persisted in the rerun state
+file so that a subsequent rerun reproduces the same execution order. An
+explicitly provided `--test-random-seed` takes precedence over the persisted
+seed.
+
 Matching files are executed as test files.
 More information on the test file execution can be found
 in the [test runner execution model][] section.

--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -214,8 +214,8 @@ function setupFailureStateFile(rootTest, globalOptions) {
   if (!globalOptions.rerunFailuresFilePath) {
     return;
   }
-  rootTest.harness.previousRuns = parsePreviousRuns(globalOptions.rerunFailuresFilePath);
-  if (rootTest.harness.previousRuns === null) {
+  const previous = parsePreviousRuns(globalOptions.rerunFailuresFilePath);
+  if (previous === null) {
     rootTest.diagnostic(`Warning: The rerun failures file at ` +
       `${globalOptions.rerunFailuresFilePath} is not a valid rerun file. ` +
       'The test runner will not be able to rerun failed tests.');
@@ -223,8 +223,9 @@ function setupFailureStateFile(rootTest, globalOptions) {
     process.exitCode = kGenericUserError;
     return;
   }
+  rootTest.harness.previousRuns = previous.runs;
   if (!process.env.NODE_TEST_CONTEXT) {
-    const reporter = reportReruns(rootTest.harness.previousRuns, globalOptions);
+    const reporter = reportReruns(previous.runs, globalOptions);
     compose(rootTest.reporter, reporter).pipe(new PassThrough());
   }
 }

--- a/lib/internal/test_runner/reporter/rerun.js
+++ b/lib/internal/test_runner/reporter/rerun.js
@@ -71,7 +71,15 @@ function reportReruns(previousRuns, globalOptions) {
     }
 
     ArrayPrototypePush(previousRuns, obj);
-    writeFileSync(globalOptions.rerunFailuresFilePath, JSONStringify(previousRuns, null, 2), 'utf8');
+    // Persist a wrapper object so that the randomization seed used for this run
+    // can be reproduced on a subsequent rerun. `runs` holds the per-attempt
+    // results consumed by the runner.
+    const state = {
+      __proto__: null,
+      seed: globalOptions.randomSeed ?? null,
+      runs: previousRuns,
+    };
+    writeFileSync(globalOptions.rerunFailuresFilePath, JSONStringify(state, null, 2), 'utf8');
   };
 };
 

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -92,6 +92,7 @@ const {
   countCompletedTest,
   kDefaultPattern,
   parseCommandLine,
+  parsePreviousRuns,
 } = require('internal/test_runner/utils');
 const {
   validateAndCanonicalizeTagFilter,
@@ -779,21 +780,17 @@ function run(options = kEmptyObject) {
   }
   if (rerunFailuresFilePath) {
     validatePath(rerunFailuresFilePath, 'options.rerunFailuresFilePath');
-    // TODO(pmarchini): Support rerun-failures with randomization by
-    // persisting the randomization seed in the rerun state file.
-    if (randomSeed != null) {
-      throw new ERR_INVALID_ARG_VALUE(
-        'options.randomSeed',
-        randomSeed,
-        'is not supported with rerun failures mode',
-      );
-    }
-    if (randomize) {
-      throw new ERR_INVALID_ARG_VALUE(
-        'options.randomize',
-        randomize,
-        'is not supported with rerun failures mode',
-      );
+    // Reproduce the randomized order recorded by a previous run. The seed
+    // persisted in the rerun state file is fed back into the run config so the
+    // rerun replays tests in the same order. An explicitly supplied seed always
+    // takes precedence. Unrecognized/legacy state files are ignored here and
+    // handled by the graceful-degradation branch in setupFailureStateFile().
+    if (randomSeed == null && !watch) {
+      const previous = parsePreviousRuns(rerunFailuresFilePath);
+      if (previous !== null && previous.seed != null) {
+        randomSeed = previous.seed;
+        randomize = true;
+      }
     }
   }
   if (randomize) {

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -1,5 +1,6 @@
 'use strict';
 const {
+  ArrayIsArray,
   ArrayPrototypeFlatMap,
   ArrayPrototypeForEach,
   ArrayPrototypeJoin,
@@ -15,6 +16,7 @@ const {
   MathMax,
   MathMin,
   MathRandom,
+  NumberIsInteger,
   NumberParseInt,
   NumberPrototypeToFixed,
   ObjectGetOwnPropertyDescriptor,
@@ -209,18 +211,52 @@ function shouldColorizeTestFiles(destinations) {
   });
 }
 
+/**
+ * Parse the rerun failures state file.
+ *
+ * The file persists a wrapper object `{ seed, runs }` where `runs` is the list
+ * of per-attempt results and `seed` is the randomization seed used for the
+ * original run (or `null` when randomization was not enabled). When the file
+ * does not exist yet a fresh wrapper with an empty `runs` list is returned.
+ *
+ * `null` is returned for any unrecognized shape (for example a legacy bare
+ * array written by older Node.js versions) so that the consumer can degrade
+ * gracefully and start a fresh run instead of crashing.
+ * @param {string} rerunFailuresFilePath
+ * @returns {{ seed: number | null, runs: object[] } | null}
+ */
 function parsePreviousRuns(rerunFailuresFilePath) {
   let data;
   try {
     data = readFileSync(rerunFailuresFilePath, 'utf8');
   } catch (err) {
     if (err.code === 'ENOENT') {
-      data = '[]';
-    } else {
-      throw err;
+      return { __proto__: null, seed: null, runs: [] };
     }
+    throw err;
   }
-  return JSONParse(data);
+
+  let parsed;
+  try {
+    parsed = JSONParse(data);
+  } catch {
+    return null;
+  }
+
+  // Reject any unrecognized shape, including the legacy bare-array format, so
+  // that the run starts fresh through the graceful-degradation path.
+  if (parsed === null || typeof parsed !== 'object' || ArrayIsArray(parsed) ||
+      !ArrayIsArray(parsed.runs)) {
+    return null;
+  }
+
+  const seed = parsed.seed;
+  if (seed !== null && (typeof seed !== 'number' || !NumberIsInteger(seed) ||
+      seed < 0 || seed > kMaxRandomSeed)) {
+    return null;
+  }
+
+  return { __proto__: null, seed, runs: parsed.runs };
 }
 
 async function getReportersMap(reporters, destinations) {

--- a/test/parallel/test-runner-cli-randomize.js
+++ b/test/parallel/test-runner-cli-randomize.js
@@ -1,17 +1,24 @@
 'use strict';
 
 require('../common');
+const tmpdir = require('../common/tmpdir');
 const assert = require('node:assert');
 const { spawnSync } = require('node:child_process');
+const { writeFileSync } = require('node:fs');
 const { join } = require('node:path');
 const { describe, it } = require('node:test');
 const fixtures = require('../common/fixtures');
 
 const testFixtures = fixtures.path('test-runner');
 const internalOrderFixture = fixtures.path('test-runner', 'randomize', 'internal-order.cjs');
-const rerunStateFile = fixtures.path('test-runner', 'rerun-state.json');
 const kShardFiles = ['a.cjs', 'b.cjs', 'c.cjs', 'd.cjs', 'e.cjs', 'f.cjs', 'g.cjs', 'h.cjs', 'i.cjs', 'j.cjs'];
 const kInternalTests = ['a', 'b', 'c', 'd', 'e'];
+
+tmpdir.refresh();
+let rerunStateCounter = 0;
+function freshRerunStateFile() {
+  return tmpdir.resolve(`rerun-state-${rerunStateCounter++}.json`);
+}
 
 function getShardOrder(stdout) {
   return Array.from(stdout.matchAll(/ok \d+ - ([a-j]\.cjs) this should pass/g), ({ 1: name }) => name);
@@ -183,34 +190,126 @@ describe('test runner randomize flags via command line', () => {
     assert.strictEqual(child.signal, null);
   });
 
-  it('should reject --test-randomize with --test-rerun-failures', () => {
+  it('should allow --test-randomize with --test-rerun-failures', () => {
     const child = spawnSync(process.execPath, [
       '--test',
+      '--test-reporter=tap',
+      '--test-concurrency=1',
       '--test-randomize',
       '--test-rerun-failures',
-      rerunStateFile,
+      freshRerunStateFile(),
       join(testFixtures, 'shards/*.cjs'),
     ]);
 
-    assert.strictEqual(child.stdout.toString(), '');
-    assert.match(child.stderr.toString(), /The property 'options\.randomize' is not supported with rerun failures mode\./);
-    assert.strictEqual(child.status, 1);
+    assert.strictEqual(child.stderr.toString(), '');
+    assert.strictEqual(child.status, 0);
     assert.strictEqual(child.signal, null);
+    assert.match(child.stdout.toString(), /# Randomized test order seed: \d+/);
   });
 
-  it('should reject --test-random-seed with --test-rerun-failures', () => {
+  it('should allow --test-random-seed with --test-rerun-failures', () => {
     const child = spawnSync(process.execPath, [
       '--test',
+      '--test-reporter=tap',
+      '--test-concurrency=1',
       '--test-random-seed=12345',
       '--test-rerun-failures',
-      rerunStateFile,
+      freshRerunStateFile(),
       join(testFixtures, 'shards/*.cjs'),
     ]);
 
-    assert.strictEqual(child.stdout.toString(), '');
-    assert.match(child.stderr.toString(), /The property 'options\.randomSeed' is not supported with rerun failures mode\./);
-    assert.strictEqual(child.status, 1);
+    assert.strictEqual(child.stderr.toString(), '');
+    assert.strictEqual(child.status, 0);
     assert.strictEqual(child.signal, null);
+    assert.match(child.stdout.toString(), /# Randomized test order seed: 12345/);
+  });
+
+  it('should persist the seed and reproduce the order on a rerun', () => {
+    const stateFile = freshRerunStateFile();
+    const args = [
+      '--test',
+      '--test-reporter=tap',
+      '--test-concurrency=1',
+      '--test-randomize',
+      '--test-rerun-failures',
+      stateFile,
+      join(testFixtures, 'shards/*.cjs'),
+    ];
+
+    // First run randomizes with a fresh seed and persists it.
+    const first = spawnSync(process.execPath, args);
+    assert.strictEqual(first.stderr.toString(), '');
+    assert.strictEqual(first.status, 0);
+    const firstOut = first.stdout.toString();
+    const seedMatch = firstOut.match(/# Randomized test order seed: (\d+)/);
+    assert(seedMatch, `Missing randomization seed diagnostic in output: ${firstOut}`);
+    const firstOrder = getShardOrder(firstOut);
+    assert.deepStrictEqual([...firstOrder].sort(), kShardFiles);
+
+    // Rerun without an explicit seed: the persisted seed must reproduce order.
+    const rerunArgs = [
+      '--test',
+      '--test-reporter=tap',
+      '--test-concurrency=1',
+      '--test-rerun-failures',
+      stateFile,
+      join(testFixtures, 'shards/*.cjs'),
+    ];
+    const second = spawnSync(process.execPath, rerunArgs);
+    assert.strictEqual(second.stderr.toString(), '');
+    assert.strictEqual(second.status, 0);
+    const secondOut = second.stdout.toString();
+    assert.match(secondOut, new RegExp(`# Randomized test order seed: ${seedMatch[1]}`));
+    const secondOrder = getShardOrder(secondOut);
+    assert.deepStrictEqual(secondOrder, firstOrder);
+  });
+
+  it('should give an explicit --test-random-seed precedence over the persisted seed', () => {
+    const stateFile = freshRerunStateFile();
+    // Seed the state file with a different persisted seed.
+    const first = spawnSync(process.execPath, [
+      '--test',
+      '--test-reporter=tap',
+      '--test-concurrency=1',
+      '--test-random-seed=11111',
+      '--test-rerun-failures',
+      stateFile,
+      join(testFixtures, 'shards/*.cjs'),
+    ]);
+    assert.strictEqual(first.status, 0);
+
+    const second = spawnSync(process.execPath, [
+      '--test',
+      '--test-reporter=tap',
+      '--test-concurrency=1',
+      '--test-random-seed=22222',
+      '--test-rerun-failures',
+      stateFile,
+      join(testFixtures, 'shards/*.cjs'),
+    ]);
+    assert.strictEqual(second.stderr.toString(), '');
+    assert.strictEqual(second.status, 0);
+    assert.match(second.stdout.toString(), /# Randomized test order seed: 22222/);
+  });
+
+  it('should start fresh with a legacy bare-array rerun state file', () => {
+    const stateFile = freshRerunStateFile();
+    // Simulate an older Node.js version that wrote a bare array.
+    writeFileSync(stateFile, JSON.stringify([{}]), 'utf8');
+
+    const child = spawnSync(process.execPath, [
+      '--test',
+      '--test-concurrency=1',
+      '--test-rerun-failures',
+      stateFile,
+      join(testFixtures, 'shards/*.cjs'),
+    ]);
+
+    // The legacy file is detected and the run degrades gracefully instead of
+    // crashing with a raw TypeError.
+    assert.strictEqual(child.signal, null);
+    assert.doesNotMatch(child.stderr.toString(), /TypeError/);
+    assert.match(child.stdout.toString(), /is not a valid rerun file/);
   });
 
   it('should reject out of range --test-random-seed values', () => {

--- a/test/parallel/test-runner-run.mjs
+++ b/test/parallel/test-runner-run.mjs
@@ -1,5 +1,6 @@
 import * as common from '../common/index.mjs';
 import * as fixtures from '../common/fixtures.mjs';
+import tmpdir from '../common/tmpdir.js';
 import { basename, join } from 'node:path';
 import { describe, it, run } from 'node:test';
 import { dot, spec, tap } from 'node:test/reporters';
@@ -8,7 +9,7 @@ import assert from 'node:assert';
 import util from 'node:util';
 
 const testFixtures = fixtures.path('test-runner');
-const rerunStateFile = join(testFixtures, 'rerun-state.json');
+tmpdir.refresh();
 
 describe('require(\'node:test\').run', { concurrency: true }, () => {
   it('should run with no tests', async () => {
@@ -693,18 +694,28 @@ describe('require(\'node:test\').run', { concurrency: true }, () => {
       });
     });
 
-    it('should not allow randomize with rerunFailuresFilePath', () => {
-      assert.throws(() => run({ randomize: true, rerunFailuresFilePath: rerunStateFile }), {
-        code: 'ERR_INVALID_ARG_VALUE',
-        message: /The property 'options\.randomize' is not supported with rerun failures mode\./,
+    it('should allow randomize with rerunFailuresFilePath', async () => {
+      const stream = run({
+        files: [],
+        randomize: true,
+        rerunFailuresFilePath: tmpdir.resolve('rerun-state-randomize.json'),
       });
+      stream.on('test:fail', common.mustNotCall());
+      stream.on('test:pass', common.mustNotCall());
+      // eslint-disable-next-line no-unused-vars
+      for await (const _ of stream);
     });
 
-    it('should not allow randomSeed with rerunFailuresFilePath', () => {
-      assert.throws(() => run({ randomSeed: 12345, rerunFailuresFilePath: rerunStateFile }), {
-        code: 'ERR_INVALID_ARG_VALUE',
-        message: /The property 'options\.randomSeed' is not supported with rerun failures mode\./,
+    it('should allow randomSeed with rerunFailuresFilePath', async () => {
+      const stream = run({
+        files: [],
+        randomSeed: 12345,
+        rerunFailuresFilePath: tmpdir.resolve('rerun-state-seed.json'),
       });
+      stream.on('test:fail', common.mustNotCall());
+      stream.on('test:pass', common.mustNotCall());
+      // eslint-disable-next-line no-unused-vars
+      for await (const _ of stream);
     });
 
     it('should not allow decimal randomSeed values', () => {

--- a/test/parallel/test-runner-test-rerun-failures.js
+++ b/test/parallel/test-runner-test-rerun-failures.js
@@ -88,14 +88,14 @@ const expectedStateFile = [
 ];
 
 const getStateFile = async () => {
-  const res = JSON.parse((await readFile(stateFile, 'utf8')).replaceAll('\\\\', '/'));
-  res.forEach((entry) => {
+  const { runs } = JSON.parse((await readFile(stateFile, 'utf8')).replaceAll('\\\\', '/'));
+  runs.forEach((entry) => {
     for (const item in entry) {
       delete entry[item].children;
       delete entry[item].duration_ms;
     }
   });
-  return res;
+  return runs;
 };
 
 test('test should pass on third rerun', async () => {
@@ -246,11 +246,11 @@ test('rerun preserves the original duration on the replayed pass', async () => {
   assert.doesNotMatch(second.stdout, /always failing[^\n]*\(passed on attempt/,
                       'the failing test must not show the replay marker');
 
-  const raw = JSON.parse(await readFile(stateFile, 'utf8'));
-  const passKey = Object.keys(raw[0]).find((k) => raw[0][k].name === 'passing slow test');
+  const { runs } = JSON.parse(await readFile(stateFile, 'utf8'));
+  const passKey = Object.keys(runs[0]).find((k) => runs[0][k].name === 'passing slow test');
   assert.ok(passKey, 'expected the passing test to be recorded on attempt 0');
-  assert.ok(raw[0][passKey].duration_ms > 0, 'expected a measurable duration on attempt 0');
-  assert.strictEqual(raw[1][passKey].duration_ms, raw[0][passKey].duration_ms);
+  assert.ok(runs[0][passKey].duration_ms > 0, 'expected a measurable duration on attempt 0');
+  assert.strictEqual(runs[1][passKey].duration_ms, runs[0][passKey].duration_ms);
 });
 
 test('using `run` api', async () => {


### PR DESCRIPTION
Draft for self-review (fork-internal, not for upstream).

Allows `--test-randomize` / `--test-random-seed` to be combined with
`--test-rerun-failures`: the randomization seed is persisted in the rerun
state file (`{ seed, runs }`) and fed back on a rerun so the original
randomized order is reproduced. An explicit `--test-random-seed` takes
precedence. Old bare-array state files are detected and the run starts fresh.

Locally verified (v27.0.0-pre): test-runner-cli-randomize.js,
test-runner-test-rerun-failures.js, test-runner-run.mjs all pass.
