### PR TITLE
test_runner: warn when --test-concurrency is dropped under isolation=none

### DIFF
--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -350,6 +350,19 @@ function parseCommandLine() {
     }
 
     if (isolation === 'none') {
+      // The default value of --test-concurrency is 0 (auto), so any truthy
+      // value other than 1 means the user explicitly requested a concurrency
+      // that cannot be honored when isolation is disabled. Surface a one-time
+      // warning instead of silently dropping the flag. See
+      // https://github.com/nodejs/node/issues/55939.
+      const explicitConcurrency = getOptionValue('--test-concurrency');
+      if (explicitConcurrency && explicitConcurrency !== 1) {
+        process.emitWarning(
+          '--test-concurrency is ignored when --test-isolation=none is set. ' +
+            'See https://github.com/nodejs/node/issues/55939',
+          'ExperimentalWarning',
+        );
+      }
       concurrency = 1;
     } else {
       concurrency = getOptionValue('--test-concurrency') || true;

--- a/test/parallel/test-runner-cli-concurrency.js
+++ b/test/parallel/test-runner-cli-concurrency.js
@@ -38,3 +38,38 @@ test('isolation=none overrides --test-concurrency', async () => {
   const cp = spawnSync(process.execPath, args, { cwd, env });
   assert.match(cp.stderr.toString(), /concurrency: 1,/);
 });
+
+const kConcurrencyIgnoredWarning =
+  '--test-concurrency is ignored when --test-isolation=none is set. ' +
+  'See https://github.com/nodejs/node/issues/55939';
+
+test('isolation=none warns when --test-concurrency is explicitly set', async () => {
+  const args = [
+    '--test', '--test-isolation=none', '--test-concurrency=4',
+  ];
+  const cp = spawnSync(process.execPath, args, { cwd, env });
+  assert(
+    cp.stderr.toString().includes(kConcurrencyIgnoredWarning),
+    `expected warning not found in stderr:\n${cp.stderr}`,
+  );
+});
+
+test('isolation=none does not warn without --test-concurrency', async () => {
+  const args = ['--test', '--test-isolation=none'];
+  const cp = spawnSync(process.execPath, args, { cwd, env });
+  assert(
+    !cp.stderr.toString().includes(kConcurrencyIgnoredWarning),
+    `unexpected warning found in stderr:\n${cp.stderr}`,
+  );
+});
+
+test('isolation=none does not warn with --test-concurrency=1', async () => {
+  const args = [
+    '--test', '--test-isolation=none', '--test-concurrency=1',
+  ];
+  const cp = spawnSync(process.execPath, args, { cwd, env });
+  assert(
+    !cp.stderr.toString().includes(kConcurrencyIgnoredWarning),
+    `unexpected warning found in stderr:\n${cp.stderr}`,
+  );
+});


### PR DESCRIPTION
Draft for self-review (fork-internal, not for upstream).

When `--test-isolation=none` is set, concurrency is forced to 1 and an
explicit `--test-concurrency` value was silently dropped. Emits a one-time
ExperimentalWarning so the user knows the flag had no effect.

JS-only heuristic: explicit `--test-concurrency=0` is indistinguishable from
unset. Locally verified: test-runner-cli-concurrency.js passes.
